### PR TITLE
explicitly state major version for network-visualization lib

### DIFF
--- a/netvis/templates/netvis/gen_netvis.html
+++ b/netvis/templates/netvis/gen_netvis.html
@@ -7,7 +7,7 @@
     <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/three@latest/build/three.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@acdh/network-visualization@latest/lib/network-visualization.umd.js"></script>
+    <script crossorigin src="https://unpkg.com/@acdh/network-visualization@0/lib/network-visualization.umd.js"></script>
     <script src="{% static 'netvis/js/netvis.js' %}"></script>
 {% endblock scriptHeader %}
 {% block content %}


### PR DESCRIPTION
import `@acdh/network-visualization` with version `0.x` instead of `latest` to allow for semver breaking changes